### PR TITLE
ALWAYS GET SYSTEM DATA DURING INIT

### DIFF
--- a/distro2sbom/distrobuilder/dpkgbuilder.py
+++ b/distro2sbom/distrobuilder/dpkgbuilder.py
@@ -18,8 +18,8 @@ class DpkgBuilder(DistroBuilder):
         self.sbom_relationship = SBOMRelationship()
         self.license = LicenseScanner()
         self.distro_packages = []
+        self.system_data = self.get_system()
         if name is None and release is None:
-            self.system_data = self.get_system()
             self.name = self.system_data["name"].replace(" ", "-")
             self.release = self.system_data["version_id"]
         else:


### PR DESCRIPTION
Instead of assuming when system data might be needed, just get it always on init. Will make future adaptions also easier since assumptions don't need to be revisited.