### PR TITLE
Support generation of SBOM from system (rpm based distro) in 'chrooted' environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,23 @@ distro2sbom --distro deb --system --format json --output-file <distrooutfile>
 
 This will generate an SBOM in SPDX JSON value for a distribution file in dpkg format (indicated by the 'deb' option)
 
+#### Specific options for rpm/yum based distro
+
+The following [optional] environment variable are available to customize rpm and yum commands used by the tool. This can be usefull for example to enable/disable some repo or to support *chrooted* environments.
+
+- **DISTRO2SBOM_ROOT_PATH** The path prefix where to get `/etc/os-release`
+- **DISTRO2SBOM_RPM_OPTIONS** Additional options passed to rpm commands (used by `rpm -qa` to list all packages and `rpm -qi <pkg>` to query information on a package)
+- **DISTRO2SBOM_YUM_OPTIONS** Additional options passed to yum commands (used by `yum repoquery --deplist <pkg>` to get dependencies)
+
+```bash
+export DISTRO2SBOM_ROOT_PATH=/path-to-distrib/slash
+export DISTRO2SBOM_RPM_OPTIONS="--root /path-to-distrib/slash"
+export DISTRO2SBOM_YUM_OPTIONS="--installroot=/path-to-distrib/slash --setopt=reposdir=/path-to-distrib/repos --setopt=install_weak_deps=False --repo=my-repo"
+distro2sbom --distro rpm --system --sbom cyclonedx --format json --output-file <distrooutfile>
+```
+
+This will generate an SBOM in CYCLONEDX JSON value for a *chrooted* distribution located at `/path-to-distrib/slash`
+
 ## Licence
 
 Licenced under the Apache 2.0 Licence.

--- a/distro2sbom/distrobuilder/distrobuilder.py
+++ b/distro2sbom/distrobuilder/distrobuilder.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2023 Anthony Harrison
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import re
 import subprocess
 import unicodedata
@@ -12,6 +13,7 @@ class DistroBuilder:
         self.sbom_packages = {}
         self.sbom_relationships = []
         self.debug = debug
+        self.root = os.environ.get('DISTRO2SBOM_ROOT_PATH', '')
 
     def get_data(self):
         pass
@@ -69,7 +71,7 @@ class DistroBuilder:
 
     def get_system(self):
         # Extract metadata from file
-        OS_FILE = "/etc/os-release"
+        OS_FILE = f"{self.root}/etc/os-release"
         metadata = {}
         filePath = Path(OS_FILE)
         # Check path exists and is a valid file

--- a/distro2sbom/distrobuilder/rpmbuilder.py
+++ b/distro2sbom/distrobuilder/rpmbuilder.py
@@ -26,6 +26,8 @@ class RpmBuilder(DistroBuilder):
             self.name = name.replace(" ", "-")
             self.release = release
         self.parent = f"Distro-{self.name}"
+        self.rpm_options = os.environ.get('DISTRO2SBOM_RPM_OPTIONS', '')
+        self.yum_options = os.environ.get('DISTRO2SBOM_YUM_OPTIONS', '')
 
     def get_data(self):
         pass
@@ -112,7 +114,7 @@ class RpmBuilder(DistroBuilder):
             self.sbom_relationships.append(self.sbom_relationship.get_relationship())
             return 0
         self.distro_packages.append(package_name)
-        out = self.run_program(f"rpm -qi {package_name}")
+        out = self.run_program(f"rpm {self.rpm_options} -qi {package_name}")
         # If package not found, no metadata returned
         if len(out) > 0:
             self.metadata = {}
@@ -130,7 +132,7 @@ class RpmBuilder(DistroBuilder):
                 return False
             # Now find package dependencies
             dependencies_out = self.run_program(
-                f"yum repoquery --deplist {package_name}"
+                f"yum repoquery {self.yum_options} --deplist {package_name}"
             )
             requires = []
             for line in dependencies_out:
@@ -272,7 +274,7 @@ class RpmBuilder(DistroBuilder):
         self.sbom_relationship.set_relationship(self.parent, "DESCRIBES", distro_root)
         self.sbom_relationships.append(self.sbom_relationship.get_relationship())
         # Get installed packages
-        out = self.run_program("rpm -qa")
+        out = self.run_program(f"rpm {self.rpm_options} -qa")
         for line in out:
             # Parse line PRODUCT-VERSION[-Other]?. If pattern not followed ignore...
             item = os.path.splitext(os.path.basename(line.strip().rstrip("\n")))[

--- a/distro2sbom/version.py
+++ b/distro2sbom/version.py
@@ -1,4 +1,4 @@
 # Copyright (C) 2024 Anthony Harrison
 # SPDX-License-Identifier: Apache-2.0
 
-VERSION: str = "0.4.3"
+VERSION: str = "0.4.4"

--- a/distro2sbom/version.py
+++ b/distro2sbom/version.py
@@ -1,4 +1,4 @@
 # Copyright (C) 2024 Anthony Harrison
 # SPDX-License-Identifier: Apache-2.0
 
-VERSION: str = "0.4.4"
+VERSION: str = "0.4.5"


### PR DESCRIPTION
#### Specific options for rpm/yum based distro

The following [optional] environment variables are available to customize rpm and yum commands used by the tool. This can be usefull for example to enable/disable some repo or to support *chrooted* environments.

- **DISTRO2SBOM_ROOT_PATH** The path prefix where to get `/etc/os-release`
- **DISTRO2SBOM_RPM_OPTIONS** Additional options passed to rpm commands (used by `rpm -qa` to list all packages and `rpm -qi <pkg>` to query information on a package)
- **DISTRO2SBOM_YUM_OPTIONS** Additional options passed to yum commands (used by `yum repoquery --deplist <pkg>` to get dependencies)

```bash
export DISTRO2SBOM_ROOT_PATH=/path-to-distrib/slash
export DISTRO2SBOM_RPM_OPTIONS="--root /path-to-distrib/slash"
export DISTRO2SBOM_YUM_OPTIONS="--installroot=/path-to-distrib/slash --setopt=reposdir=/path-to-distrib/repos --setopt=install_weak_deps=False --repo=my-repo"
distro2sbom --distro rpm --system --sbom cyclonedx --format json --output-file <distrooutfile>
```

This will generate an SBOM in CYCLONEDX JSON value for a *chrooted* distribution located at `/path-to-distrib/slash`