### PR TITLE
fix: Make debian license collection more robust

### DIFF
--- a/distro2sbom/distrobuilder/dpkgbuilder.py
+++ b/distro2sbom/distrobuilder/dpkgbuilder.py
@@ -105,7 +105,7 @@ class DpkgBuilder(DistroBuilder):
         filename = Path(base_file)
         # Check path exists and is a valid file
         if filename.exists() and filename.is_file():
-            with open(filename, "r") as f:
+            with open(filename, "r", errors="replace") as f:
                 lines = f.readlines()
                 copyright_found = False
                 license_found = False


### PR DESCRIPTION
Thanks for the great tool. While playing around with it I've stumbled over some stackstraces complaining about an `UnicodeError` while parsing the `copyright` file of certain Debian packages. It turns out that some files have characters which are not decodable in utf8 (encoding is always fun, isn't it?). My suggested fix is to use Python's fallback mechanism with `open(..., errors="replace")`