### PR TITLE
Add purl to Debian --input-file processing

### DIFF
--- a/distro2sbom/distrobuilder/dpkgbuilder.py
+++ b/distro2sbom/distrobuilder/dpkgbuilder.py
@@ -65,7 +65,7 @@ class DpkgBuilder(DistroBuilder):
                         " +", " ", line[2:].strip().rstrip("\n")
                     ).split(" ")
                     self.sbom_package.initialise()
-                    package = line_element[0].lower().replace("_", "-")
+                    package = line_element[0].lower().replace("_", "-").split(":")[0]
                     version = line_element[1]
                     self.sbom_package.set_name(package)
                     self.sbom_package.set_version(version)

--- a/distro2sbom/distrobuilder/dpkgbuilder.py
+++ b/distro2sbom/distrobuilder/dpkgbuilder.py
@@ -77,6 +77,9 @@ class DpkgBuilder(DistroBuilder):
                     self.sbom_package.set_supplier("UNKNOWN", "NOASSERTION")
                     description = " ".join(n for n in line_element[3:])
                     self.sbom_package.set_summary(description)
+                    self.sbom_package.set_purl(
+                        f"pkg:deb/{self.get_namespace()}{package}@{version}"
+                    )
                     # Store package data
                     self.sbom_packages[
                         (


### PR DESCRIPTION
The intent here is to produce `purl`s for CycloneDX output when using `dpkg -l` output with `--input-file`.

The precense of colons in the `purl` breaks the spec and they don't appear when using the `--system` method so I just trim them off with the arch info. E.g. making a `purl` out of `bind9-libs:amd64` directly would produce an invalid `purl`.

This is just to get a minimal `purl` - looking at the example `pkg:deb/debian/curl@7.50.3-1?arch=i386&distro=jessie` from https://github.com/package-url/purl-spec?tab=readme-ov-file#some-purl-examples the arch info I'm trimming could be added with `?arch=...`. But this wouldn't match the `--system` output. What do you think?

Thanks for the tool - these tweaks would make it suitable for my usecase.